### PR TITLE
Ensure env vars propagate in deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ some parts of the game.
 
 ### Quick deployment
 
-Run `yarn deploy` for a guided setup that installs dependencies, runs migrations, builds the client and starts the server.
+Run `yarn deploy` for a guided setup that installs dependencies, runs migrations, builds the client and starts the server. The script writes a `.env` file and also assigns `process.env.DATABASE_URL` and `process.env.PORT`, ensuring migrations and the server inherit these values.
 Please refer to usage instructions in the [Steam workshop item](https://steamcommunity.com/sharedfiles/filedetails/?id=2085044664).
 
 ## Contribution

--- a/deploy.js
+++ b/deploy.js
@@ -24,19 +24,26 @@ async function main() {
   fs.writeFileSync('.env', envContent);
   console.log('Created .env file.');
 
+  // Update process.env so subsequent commands inherit these values
+  process.env.DATABASE_URL = answers.database;
+  process.env.PORT = answers.port;
+
   console.log('Installing dependencies...');
   execSync('yarn install', { stdio: 'inherit' });
 
   console.log('Running database migrations...');
-  execSync('npx sequelize-cli db:migrate', { stdio: 'inherit' });
+  execSync('npx sequelize-cli db:migrate', {
+    stdio: 'inherit',
+    env: { ...process.env }
+  });
 
   console.log('Building client...');
-  execSync('yarn build', { stdio: 'inherit' });
+  execSync('yarn build', { stdio: 'inherit', env: { ...process.env } });
 
   console.log('Starting server...');
   execSync('node server/server.js', {
     stdio: 'inherit',
-    env: { ...process.env, DATABASE_URL: answers.database, PORT: answers.port }
+    env: { ...process.env }
   });
 }
 


### PR DESCRIPTION
## Summary
- update `deploy.js` to assign `DATABASE_URL` and `PORT` to `process.env`
- inherit these env vars for migrations, build and server commands
- clarify quick deployment section in `README.md`

## Testing
- `yarn install`
- `CI=true yarn test --watchAll=false` *(fails: Unable to find element with text /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_68851519bea4832dbafa83bd08cc3c50